### PR TITLE
Fixed App crash after few second

### DIFF
--- a/android/src/main/java/com/reactnativepedometerdetails/step/background/Restarter.kt
+++ b/android/src/main/java/com/reactnativepedometerdetails/step/background/Restarter.kt
@@ -11,7 +11,8 @@ class Restarter : BroadcastReceiver() {
 
         // restart the step counting service (different code to achieve this depending on Android version)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            context.startForegroundService(Intent(context, StepCounterService::class.java))
+            // context.startForegroundService(Intent(context, StepCounterService::class.java))
+            context.startService(Intent(context, StepCounterService::class.java))
         } else {
             context.startService(Intent(context, StepCounterService::class.java))
         }


### PR DESCRIPTION
Hi zaixiaoqu,  Restarter.kt file has a if else condition where the if condition crashes the app after few seconds, so I have moved the else condition to if and now the pedometer works fine without any issues,


文件有一个 if else 条件，其中 if 条件在几秒钟后使应用程序崩溃，所以我已将 else 条件移至 if ，现在计步器工作正常，没有任何问题